### PR TITLE
MicrosoftTeamsClient - Added Layout support for ApplicationName + MachineName

### DIFF
--- a/src/NLog.Targets.MicrosoftTeams/MicrosoftTeamsClient.cs
+++ b/src/NLog.Targets.MicrosoftTeams/MicrosoftTeamsClient.cs
@@ -10,7 +10,6 @@ namespace NLog.Targets.MicrosoftTeams
     public class MicrosoftTeamsClient
     {
         private readonly Uri _uri;
-        private readonly HttpClient _client = new HttpClient();
 
         public MicrosoftTeamsClient(string url)
         {
@@ -29,7 +28,7 @@ namespace NLog.Targets.MicrosoftTeams
             var message = CreateMessageCard(title, logMessage, facts);
             var json = JsonConvert.SerializeObject(message);
 
-            var response = await SendMessage(json);
+            var response = await SendMessage(json).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 throw new InvalidOperationException($"Rest Call Failed - {response.ReasonPhrase}");
@@ -48,7 +47,7 @@ namespace NLog.Targets.MicrosoftTeams
             using (var httpClient = new HttpClient())
             {
                 var targetUrl = _uri;
-                return await httpClient.PostAsync(targetUrl, messageContent);
+                return await httpClient.PostAsync(targetUrl, messageContent).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
So you can do this:

```xml
 <target xsi:type="MicrosoftTeams" 
         name="msTeams" 
         WebhookUrl="${configsetting:name=Logging.TeamsUrl}"          
         ApplicationName="Your Application Name"
         CardTitle="Title - ${level:uppercase=true}: ${date} - [${logger}]"
         layout="[${level:uppercase=true}] ${logger} - ${message} ${all-event-properties}"
    />
```