### PR TITLE
Support custom Facts with fallback to default Facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ NLog.config
 
 ```xml
 
-<!-- Example for setting Webhook URL inside nlog.conf -->
+<!-- Example for setting Webhook URL inside nlog.config -->
 <!-- write logs to Microsoft Teams -->
 <target xsi:type="MicrosoftTeams, NLog.Targets.MicrosoftTeams" 
          name="msTeams" 

--- a/src/NLog.Targets.MicrosoftTeams/MicrosoftTeamsClient.cs
+++ b/src/NLog.Targets.MicrosoftTeams/MicrosoftTeamsClient.cs
@@ -23,27 +23,23 @@ namespace NLog.Targets.MicrosoftTeams
         /// <param name="logMessage">Log message</param>
         /// <param name="facts"></param>
         /// <returns></returns>
-        public async Task CreateAndSendMessage(string title, string logMessage, string level, Dictionary<string, string> facts)
+        public async Task CreateAndSendMessage(string title, string level, Dictionary<string, string> facts)
         {
-            var message = CreateMessageCard(title, logMessage, level, facts);
-            var json = JsonConvert.SerializeObject(message);
+            var message = CreateMessageCard(title, level, facts);
+            var jsonContent = JsonConvert.SerializeObject(message);
 
-            NLog.Common.InternalLogger.Log(LogLevel.Info, json);
+            NLog.Common.InternalLogger.Debug("MicrosoftTeamsTarget - JSON:{0}{1}", Environment.NewLine, jsonContent);
             
-            var response = await SendMessage(json).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new InvalidOperationException($"Rest Call Failed - {response.ReasonPhrase}");
-            }
+            var response = await SendMessage(jsonContent).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode(); // Throws when not success http statuscode
         }
 
         /// <summary>
         /// posts the message to the url
         /// </summary>
-        /// <param name="logMessage"></param>
-        private async Task<HttpResponseMessage> SendMessage(string logMessage)
+        private async Task<HttpResponseMessage> SendMessage(string jsonContent)
         {
-            var messageContent = new StringContent(logMessage);
+            var messageContent = new StringContent(jsonContent);
             messageContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
 
             using (var httpClient = new HttpClient())
@@ -56,12 +52,7 @@ namespace NLog.Targets.MicrosoftTeams
         /// <summary>
         /// Creates the Message string with card title
         /// </summary>
-        /// <param name="title"></param>
-        /// <param name="logMessage"></param>
-        /// <param name="level"></param>
-        /// <param name="facts"></param>
-        /// <returns></returns>
-        private MicrosoftTeamsMessageCard CreateMessageCard(string title, string logMessage, string level, Dictionary<string, string> facts)
+        private MicrosoftTeamsMessageCard CreateMessageCard(string title, string level, Dictionary<string, string> facts)
         {
             var request = new MicrosoftTeamsMessageCard
             {

--- a/src/NLog.Targets.MicrosoftTeams/MicrosoftTeamsTarget.cs
+++ b/src/NLog.Targets.MicrosoftTeams/MicrosoftTeamsTarget.cs
@@ -29,8 +29,14 @@ namespace NLog.Targets.MicrosoftTeams
         /// <summary>
         /// The machine name of the computer
         /// </summary>
+        [Obsolete("Use HostName instead of MachineName.")]
+        public Layout MachineName { get => HostName; set => HostName = value; }
+
+        /// <summary>
+        /// The machine name of the computer
+        /// </summary>
         [RequiredParameter]
-        public Layout MachineName { get; set; }
+        public Layout HostName { get; set; }
 
         /// <summary>
         /// CardTitle
@@ -38,13 +44,39 @@ namespace NLog.Targets.MicrosoftTeams
         [RequiredParameter]
         public Layout CardTitle { get; set; }
 
-        // <summary>
+        /// <summary>
+        /// Facts
+        /// </summary>
+        [ArrayParameter(typeof(TargetPropertyWithContext), "fact")]
+        public virtual IList<TargetPropertyWithContext> Facts => ContextProperties;
+
+        /// <summary>
         /// Construction
         /// </summary>        
         public MicrosoftTeamsTarget()
         {
-            IncludeEventProperties = true; // Include LogEvent Properties by default
-            MachineName = "${machinename}";
+            CardTitle = "${logger}";
+            HostName = "${hostname}";
+            Layout = "${message}";
+            ApplicationName = "${appdomain:format=friendly}";
+        }
+
+        protected override void InitializeTarget()
+        {
+            if (this.Facts.Count == 0)
+            {
+                // Add default facts whene none provided
+                this.Facts.Add(new TargetPropertyWithContext("Application", this.ApplicationName));
+                this.Facts.Add(new TargetPropertyWithContext("Message", this.Layout));
+                this.Facts.Add(new TargetPropertyWithContext("Level", "${level}"));
+                this.Facts.Add(new TargetPropertyWithContext("Logger", "${logger}"));
+                this.Facts.Add(new TargetPropertyWithContext("HostName", this.HostName));
+                this.Facts.Add(new TargetPropertyWithContext("Exception Type", "${exception:format=type}"));
+                this.Facts.Add(new TargetPropertyWithContext("Exception Message", "${exception:format=message}"));
+                this.Facts.Add(new TargetPropertyWithContext("Exception Stacktrace", "${exception:format=stacktrace}"));
+            }
+
+            base.InitializeTarget();
         }
 
         /// <summary>
@@ -55,33 +87,37 @@ namespace NLog.Targets.MicrosoftTeams
         /// <returns></returns>
         protected override async Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken)
         {
-            var facts = new Dictionary<string, string>();
-
-            var applicationName = RenderLogEvent(this.ApplicationName, logEvent);
-            var machineName = RenderLogEvent(this.MachineName, logEvent);
-            var level = logEvent.Level.ToString();
-
-            facts.Add("Application", applicationName);
-            facts.Add("Machine", machineName);
-            facts.Add("Level", level);
-            facts.Add("Logger", logEvent.LoggerName);
-            facts.Add("Message", logEvent.Message);
-
-            // Add exception fields if exception occurred
-            var exception = logEvent.Exception;
-            if (exception != null)
+            var facts = new Dictionary<string, string>(this.Facts.Count);
+            foreach (var fact in this.Facts)
             {
-                facts.Add("Exception Type", exception.GetType().Name);
-                facts.Add("Exception Message", exception.Message);
-                facts.Add("Stacktrace", exception.StackTrace?.ToString());
+                var factName = fact.Name;
+                if (string.IsNullOrEmpty(factName))
+                    continue;
+                var factValue = RenderLogEvent(fact.Layout, logEvent);
+                if (!fact.IncludeEmptyValue && string.IsNullOrEmpty(factValue))
+                    continue;
+                facts[factName] = factValue;
+            }
+            if (this.IncludeEventProperties && logEvent.HasProperties)
+            {
+                var excludeProperties = this.ExcludeProperties?.Count > 0 ? this.ExcludeProperties : null;
+                foreach (var prop in logEvent.Properties)
+                {
+                    var propName = prop.Key?.ToString() ?? string.Empty;
+                    if (string.IsNullOrEmpty(propName))
+                        continue;
+                    if (excludeProperties?.Contains(propName) == true)
+                        continue;
+                    facts[propName] = prop.Value?.ToString() ?? string.Empty;
+                }
             }
 
+            var level = logEvent.Level.ToString();
             var title = RenderLogEvent(this.CardTitle, logEvent);
-            string logMessage = RenderLogEvent(this.Layout, logEvent);
             var webHookUrl = RenderLogEvent(this.WebhookUrl, logEvent);
 
             var client = new MicrosoftTeamsClient(webHookUrl);
-            await client.CreateAndSendMessage(title, logMessage, level, facts).ConfigureAwait(false);
+            await client.CreateAndSendMessage(title, level, facts).ConfigureAwait(false);
         }       
     }
 }

--- a/src/NLog.Targets.MicrosoftTeams/NLog.Targets.MicrosoftTeams.csproj
+++ b/src/NLog.Targets.MicrosoftTeams/NLog.Targets.MicrosoftTeams.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NLog" Version="5.1.1" />
+    <PackageReference Include="NLog" Version="5.3.4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
```xml
<target xsi:type="MicrosoftTeams, NLog.Targets.MicrosoftTeams" 
         name="msTeams" 
         WebhookUrl="Your Teams Webhook URL here"          
         ApplicationName="Your Application Name"
         CardTitle="Title - ${level:uppercase=true}: ${date} - [${logger}]"
         layout="[${level:uppercase=true}] ${logger} - ${message} ${all-event-properties}">
         <fact name="Message" layout="${message}" /> <!-- Custom facts, instead of default facts -->
         <fact name="Exception" layout="${exception}" /> <!-- Custom facts, instead of default facts -->
</target>
```

If specifying `IncludeEventProperties = true` then NLog LogEventInfo.Properties from structured logging will be included as additional facts.